### PR TITLE
assay_name switch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: miaTime
 Type: Package
 Title: Microbiome Time Series Analysis
-Version: 0.1.18
+Version: 0.1.19
 Authors@R:
      c(person(given = "Leo", family = "Lahti", role = c("aut"),
               email = "leo.lahti@iki.fi",

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
 
+Changes in version 0.1.19
++ changed assay_name to assay.type
+
 Changes in version 0.1.8
 + Improved the function getBaselineDivergence
 

--- a/R/getBaselineDivergence.R
+++ b/R/getBaselineDivergence.R
@@ -55,7 +55,7 @@
 #'                               time_field = "time",
 #'                               name_divergence = "divergence_from_baseline",
 #'                               name_timedifference = "time_from_baseline",
-#'                               assay_name="relabundance",
+#'                               assay.type="relabundance",
 #'                               FUN = vegan::vegdist,
 #'                               method="bray")
 #'
@@ -65,7 +65,7 @@
 #'                               time_field = "time",
 #'                               name_divergence = "divergence_from_baseline",
 #'                               name_timedifference = "time_from_baseline",
-#'                               assay_name="relabundance",
+#'                               assay.type="relabundance",
 #'                               FUN = vegan::vegdist,
 #'                               method="bray")
 #'
@@ -76,7 +76,7 @@ getBaselineDivergence <- function(x,
                             time_field,
                             name_divergence = "divergence_from_baseline",
                             name_timedifference = "time_from_baseline",			    
-                            assay_name = "counts",
+                            assay.type = "counts",
                             FUN = vegan::vegdist,
                             method="bray",
                             baseline_sample=NULL,
@@ -159,12 +159,12 @@ getBaselineDivergence <- function(x,
     if (ncol(baseline) == 1) {
         xli <- lapply(names(spl), function (g) {
             .calculate_divergence_from_baseline(x[,spl[[g]]], baseline,
-	        time_field, name_divergence, name_timedifference, assay_name, FUN,
+	        time_field, name_divergence, name_timedifference, assay.type, FUN,
 	        method, dimred, n_dimred, ...)})
     } else {
         xli <- lapply(names(spl), function (g) {
             .calculate_divergence_from_baseline(x[,spl[[g]]], baseline[, baseline_sample[[g]]],
-	        time_field, name_divergence, name_timedifference, assay_name, FUN,
+	        time_field, name_divergence, name_timedifference, assay.type, FUN,
 	        method, dimred, n_dimred, ...)})
     }
 
@@ -193,7 +193,7 @@ getBaselineDivergence <- function(x,
 #' @importFrom methods is
 .calculate_divergence_from_baseline <- function (x, baseline, time_field,
                                                  name_divergence, name_timedifference,
-                                                 assay_name, FUN, method,
+                                                 assay.type, FUN, method,
                                                  dimred, n_dimred) {
 
     # Global vars
@@ -216,8 +216,8 @@ getBaselineDivergence <- function(x,
     }
 
     # Getting corresponding matrices, to calculate divergence 
-    mat <- .get_mat_from_sce(x, assay_name, dimred, n_dimred)
-    ref_mat <- .get_mat_from_sce(reference, assay_name, dimred, n_dimred)
+    mat <- .get_mat_from_sce(x, assay.type, dimred, n_dimred)
+    ref_mat <- .get_mat_from_sce(reference, assay.type, dimred, n_dimred)
     
     # transposing mat if taken from reducedDim 
     if (!is.null(dimred)) mat <- t(mat)

--- a/R/getStepwiseDivergence.R
+++ b/R/getStepwiseDivergence.R
@@ -21,8 +21,8 @@
 #' @param name_timedifference field name for adding the time difference between
 #' samples used to calculate beta diversity
 #' (default: \code{name_timedifference = "time_difference"})
-#' @param assay_name character indicating which assay values are used in
-#' the dissimilarity estimation (default: \code{assay_name = "counts"}).
+#' @param assay.type character indicating which assay values are used in
+#' the dissimilarity estimation (default: \code{assay.type = "counts"}).
 #' @param FUN a \code{function} for dissimilarity calculation. The function must
 #'   expect the input matrix as its first argument. With rows as samples 
 #'   and columns as features. By default, \code{FUN} is
@@ -70,7 +70,7 @@
 #' tse2 <- getStepwiseDivergence(tse, group = "subject",
 #'                               time_interval = 1,
 #'                               time_field = "time",
-#'                               assay_name="relabundance",
+#'                               assay.type="relabundance",
 #'                               FUN = vegan::vegdist,
 #'                               method="bray")
 #'
@@ -82,7 +82,7 @@ getStepwiseDivergence <- function(x,
                             time_interval=1,
                             name_divergence = "time_divergence",
                             name_timedifference = "time_difference",
-                            assay_name = "counts",
+                            assay.type = "counts",
                             FUN = vegan::vegdist,
                             method="bray",
                             altexp = NULL,
@@ -126,7 +126,7 @@ getStepwiseDivergence <- function(x,
                                         name_divergence = name_divergence,
                                         name_timedifference = name_timedifference,
                                         time_field,
-                                        assay_name,
+                                        assay.type,
                                         method,
                                         altexp,
                                         dimred,
@@ -209,14 +209,14 @@ setMethod("getTimeDivergence",
                                 name_divergence = "time_divergence",
                                 name_timedifference = "time_difference",
                                 time_field,
-                                assay_name,
+                                assay.type,
                                 method,
                                 altexp,
                                 dimred,
                                 n_dimred,
                                 ...){
 
-    mat <- .get_mat_from_sce(x, assay_name, dimred, n_dimred)
+    mat <- .get_mat_from_sce(x, assay.type, dimred, n_dimred)
     ## transposing mat if taken from assay 
     if (is.null(dimred)) mat <- t(mat)
     

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ citation("miaTime")
 ## 
 ## Kindly cite the miaTime R package as follows:
 ## 
-##   (C) Yagmur Simsek and Leo Lahti. miaTime R package Version 0.1.18
+##   (C) Yagmur Simsek and Leo Lahti. miaTime R package Version 0.1.19
 ##   Package URL: microbiome.github.io/miaTime
 ## 
 ## A BibTeX entry for LaTeX users is
@@ -46,7 +46,7 @@ citation("miaTime")
 ##     title = {miaTime R package},
 ##     author = {Yagmur Simsek and Leo Lahti},
 ##     url = {microbiome.github.io/miaTime},
-##     note = {Version 0.1.18},
+##     note = {Version 0.1.19},
 ##   }
 ```
 

--- a/man/getBaselineDivergence.Rd
+++ b/man/getBaselineDivergence.Rd
@@ -10,7 +10,7 @@ getBaselineDivergence(
   time_field,
   name_divergence = "divergence_from_baseline",
   name_timedifference = "time_from_baseline",
-  assay_name = "counts",
+  assay.type = "counts",
   FUN = vegan::vegdist,
   method = "bray",
   baseline_sample = NULL,
@@ -39,8 +39,8 @@ time series field in \code{colData}.}
 samples used to calculate beta diversity
 (default: \code{name_timedifference = "time_difference"})}
 
-\item{assay_name}{character indicating which assay values are used in
-the dissimilarity estimation (default: \code{assay_name = "counts"}).}
+\item{assay.type}{character indicating which assay values are used in
+the dissimilarity estimation (default: \code{assay.type = "counts"}).}
 
 \item{FUN}{a \code{function} for dissimilarity calculation. The function must
 expect the input matrix as its first argument. With rows as samples
@@ -106,7 +106,7 @@ tse2 <- getBaselineDivergence(tse,
                               time_field = "time",
                               name_divergence = "divergence_from_baseline",
                               name_timedifference = "time_from_baseline",
-                              assay_name="relabundance",
+                              assay.type="relabundance",
                               FUN = vegan::vegdist,
                               method="bray")
 
@@ -116,7 +116,7 @@ tse2 <- getBaselineDivergence(tse,
                               time_field = "time",
                               name_divergence = "divergence_from_baseline",
                               name_timedifference = "time_from_baseline",
-                              assay_name="relabundance",
+                              assay.type="relabundance",
                               FUN = vegan::vegdist,
                               method="bray")
 

--- a/man/getStepwiseDivergence.Rd
+++ b/man/getStepwiseDivergence.Rd
@@ -13,7 +13,7 @@ getStepwiseDivergence(
   time_interval = 1,
   name_divergence = "time_divergence",
   name_timedifference = "time_difference",
-  assay_name = "counts",
+  assay.type = "counts",
   FUN = vegan::vegdist,
   method = "bray",
   altexp = NULL,
@@ -49,8 +49,8 @@ increase this accordingly.}
 samples used to calculate beta diversity
 (default: \code{name_timedifference = "time_difference"})}
 
-\item{assay_name}{character indicating which assay values are used in
-the dissimilarity estimation (default: \code{assay_name = "counts"}).}
+\item{assay.type}{character indicating which assay values are used in
+the dissimilarity estimation (default: \code{assay.type = "counts"}).}
 
 \item{FUN}{a \code{function} for dissimilarity calculation. The function must
 expect the input matrix as its first argument. With rows as samples
@@ -102,7 +102,7 @@ tse <- tse[, colData(tse)$subject \%in\% c("900", "934", "843", "875")]
 tse2 <- getStepwiseDivergence(tse, group = "subject",
                               time_interval = 1,
                               time_field = "time",
-                              assay_name="relabundance",
+                              assay.type="relabundance",
                               FUN = vegan::vegdist,
                               method="bray")
 


### PR DESCRIPTION
Switching the derivatives of `assay_name` to `assay.type` to support the same convention as _scater_ and _scuttle_. 