### PR TITLE
Fix divergence function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,8 @@ Suggests:
     BiocStyle,
     testthat,
     zoo
+Remotes:
+    github::microbiome/mia
 Encoding: UTF-8
 URL: https://github.com/microbiome/miaTime
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: miaTime
 Type: Package
 Title: Microbiome Time Series Analysis
-Version: 0.1.21
+Version: 0.1.22
 Authors@R:
      c(person(given = "Leo", family = "Lahti", role = c("aut"),
               email = "leo.lahti@iki.fi",

--- a/R/getBaselineDivergence.R
+++ b/R/getBaselineDivergence.R
@@ -220,11 +220,15 @@ getBaselineDivergence <- function(x,
     ref_mat <- .get_mat_from_sce(reference, assay.type, dimred, n_dimred)
     
     # transposing mat if taken from reducedDim 
-    if (!is.null(dimred)) mat <- t(mat)
+    if (!is.null(dimred)){
+        mat <- t(mat)
+        ref_mat <- t(ref_mat)
+    }
     
     # Beta divergence from baseline info
-    divergencevalues <- .calc_reference_dist(mat, as.vector(ref_mat),
-                                             FUN = FUN, method)
+    divergencevalues <- mia:::.calc_divergence(
+        cbind(mat, ref_mat), colnames(ref_mat), FUN = FUN, method = method)
+    divergencevalues <- divergencevalues[seq_len(ncol(mat)), "value"]
 
     # Add time divergence from baseline info; note this has to be a list    
     timevalues <- list(colData(x)[, time_field] - colData(reference)[, time_field])

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,6 @@
 # internal methods loaded from other packages
 
 .check_altExp_present <- mia:::.check_altExp_present
-.calc_reference_dist <- mia:::.calc_reference_dist
 .get_mat_from_sce <- scater:::.get_mat_from_sce
 
 ################################################################################


### PR DESCRIPTION
getBaselineDivergence() utilizes mia. mia function was updated, which lead breaking this function. This fixes the breakage but does not remove the need for updating the divergence functions in miaTime.