### PR TITLE
Install mia from Bioconductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,8 +43,6 @@ Suggests:
     scater,
     testthat,
     vegan
-Remotes:
-    github::microbiome/mia
 URL: https://github.com/microbiome/miaTime
 BugReports: https://github.com/microbiome/miaTime/issues
 Encoding: UTF-8


### PR DESCRIPTION
mia is temporarily installed from GH as the newest version is not yet in Bioconductor. Merge this PR when the Bioc devel is updated.